### PR TITLE
Feature/user public private

### DIFF
--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -43,7 +43,7 @@ class Public::UsersController < Public::ApplicationController
 
   private
    def user_params
-     params.require(:user).permit(:name, :email, :profile_image, :public_status)
+     params.require(:user).permit(:name, :email, :profile_image)
    end
 
    def check_guest_user

--- a/app/controllers/public/users_controller.rb
+++ b/app/controllers/public/users_controller.rb
@@ -43,7 +43,7 @@ class Public::UsersController < Public::ApplicationController
 
   private
    def user_params
-     params.require(:user).permit(:name, :email, :profile_image)
+     params.require(:user).permit(:name, :email, :profile_image, :public_status)
    end
 
    def check_guest_user

--- a/app/views/public/users/edit.html.erb
+++ b/app/views/public/users/edit.html.erb
@@ -16,12 +16,6 @@
             <%= f.label :image %><br />
             <%= f.file_field :image, accept: "image/*", class: "w-50" %>
           </div>
-          <div class="field mt-4">
-            <%= f.radio_button :public_status, true %>
-            <%= f.label :public_status_true, "公開", class: "mr-3" %>
-            <%= f.radio_button :public_status, false %>
-            <%= f.label :public_status_true, "非公開" %>
-          </div>
           <div class="actions">
             <%= f.submit "更新", class: "btn btn-outline-success mt-4" %>
           </div>

--- a/app/views/public/users/edit.html.erb
+++ b/app/views/public/users/edit.html.erb
@@ -12,9 +12,15 @@
             <%= f.label :email %><br />
             <%= f.email_field :email, placeholder: "eiga@sample.com", class: "w-50" %>
           </div>
-           <div class="field">
+          <div class="field">
             <%= f.label :image %><br />
             <%= f.file_field :image, accept: "image/*", class: "w-50" %>
+          </div>
+          <div class="field mt-4">
+            <%= f.radio_button :public_status, true %>
+            <%= f.label :public_status_true, "公開", class: "mr-3" %>
+            <%= f.radio_button :public_status, false %>
+            <%= f.label :public_status_true, "非公開" %>
           </div>
           <div class="actions">
             <%= f.submit "更新", class: "btn btn-outline-success mt-4" %>

--- a/db/migrate/20241211102627_remove_public_status_from_user.rb
+++ b/db/migrate/20241211102627_remove_public_status_from_user.rb
@@ -1,0 +1,5 @@
+class RemovePublicStatusFromUser < ActiveRecord::Migration[6.1]
+  def change
+    remove_column :users, :public_status, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2024_12_10_075316) do
+ActiveRecord::Schema.define(version: 2024_12_11_102627) do
 
   create_table "active_storage_attachments", force: :cascade do |t|
     t.string "name", null: false
@@ -112,7 +112,6 @@ ActiveRecord::Schema.define(version: 2024_12_10_075316) do
     t.string "email", default: "", null: false
     t.string "encrypted_password", default: "", null: false
     t.string "name", null: false
-    t.boolean "public_status", default: true, null: false
     t.string "reset_password_token"
     t.datetime "reset_password_sent_at"
     t.datetime "remember_created_at"


### PR DESCRIPTION
userの公開・非公開設定削除
まずプロフィールは名前と画像しかない点と、名前は特別決まりがあるわけではないのと画像は登録しないことも可能な観点から非公開・公開設定は必要ないと判断
またプロフィールに伴った投稿を公開しないことはレビューサイトの目的と違うから